### PR TITLE
chore: add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mswjs/is-node-process"
+  },
   "scripts": {
     "browser": "open test/browser.html",
     "electron": "electron test/fixtures/electron.js",


### PR DESCRIPTION
So that the [NPM page](https://www.npmjs.com/package/is-node-process) will link to the repository correctly. 